### PR TITLE
feature: add fscli helper tool

### DIFF
--- a/fscli
+++ b/fscli
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker exec -it freeswitch fs_cli


### PR DESCRIPTION
adds a helper command line tool to exec into the Docker container into the Freeswitch CLI when it's up